### PR TITLE
Efficiency improvements

### DIFF
--- a/glocal_exploration_ros/include/glocal_exploration_ros/glocal_system.h
+++ b/glocal_exploration_ros/include/glocal_exploration_ros/glocal_system.h
@@ -27,8 +27,9 @@ class GlocalSystem {
     // rate at which to check for imminent collisions
     FloatingPoint collision_check_period_s = 0.1f;
     // maximum rate at which the planner are updated
-    // NOTE: This is mainly used to avoid excessively fast updates
-    //       when planners are idling while waiting to reach the next waypoint.
+    // NOTE: This is mainly used to avoid excessively fast updates when planners
+    //       are idling while waiting to reach the next waypoint.
+    //       The local planner is not affected by this setting.
     FloatingPoint max_planner_update_frequency = 100.f;  // hz
 
     Config();

--- a/glocal_exploration_ros/include/glocal_exploration_ros/glocal_system.h
+++ b/glocal_exploration_ros/include/glocal_exploration_ros/glocal_system.h
@@ -26,6 +26,10 @@ class GlocalSystem {
     FloatingPoint replan_timeout_velocity = 0.f;
     // rate at which to check for imminent collisions
     FloatingPoint collision_check_period_s = 0.1f;
+    // maximum rate at which the planner are updated
+    // NOTE: This is mainly used to avoid excessively fast updates
+    //       when planners are idling while waiting to reach the next waypoint.
+    FloatingPoint max_planner_update_frequency = 100.f;  // hz
 
     Config();
     void checkParams() const override;

--- a/glocal_exploration_ros/include/glocal_exploration_ros/mapping/threadsafe_wrappers/threadsafe_voxgraph_server.h
+++ b/glocal_exploration_ros/include/glocal_exploration_ros/mapping/threadsafe_wrappers/threadsafe_voxgraph_server.h
@@ -33,6 +33,8 @@ class ThreadsafeVoxgraphServer : public voxgraph::VoxgraphMapper {
     if (submap_added_successfully && external_new_submap_callback_) {
       external_new_submap_callback_();
     }
+
+    return submap_added_successfully;
   }
 
   void setExternalNewSubmapCallback(Function callback) {

--- a/glocal_exploration_ros/src/glocal_system.cpp
+++ b/glocal_exploration_ros/src/glocal_system.cpp
@@ -16,6 +16,8 @@ void GlocalSystem::Config::checkParams() const {
   checkParamGT(replan_position_threshold, 0.f, "replan_position_threshold");
   checkParamGT(replan_yaw_threshold, 0.f, "replan_yaw_threshold");
   checkParamGT(collision_check_period_s, 0.f, "collision_check_period_s");
+  checkParamGT(max_planner_update_frequency, 0.f,
+               "max_planner_update_frequency");
 }
 
 void GlocalSystem::Config::fromRosParam() {
@@ -25,6 +27,7 @@ void GlocalSystem::Config::fromRosParam() {
   rosParam("replan_timeout_constant", &replan_timeout_constant);
   rosParam("replan_timeout_velocity", &replan_timeout_velocity);
   rosParam("collision_check_period_s", &collision_check_period_s);
+  rosParam("max_planner_update_frequency", &max_planner_update_frequency);
 }
 
 void GlocalSystem::Config::printFields() const {
@@ -34,6 +37,7 @@ void GlocalSystem::Config::printFields() const {
   printField("replan_timeout_constant", replan_timeout_constant);
   printField("replan_timeout_velocity", replan_timeout_velocity);
   printField("collision_check_period_s", collision_check_period_s);
+  printField("max_planner_update_frequency", max_planner_update_frequency);
 }
 
 GlocalSystem::GlocalSystem(const ros::NodeHandle& nh,
@@ -116,7 +120,7 @@ void GlocalSystem::mainLoop() {
   // NOTE: This is mainly intended to avoid spinning at unlimited rates in case
   //       a loopIteration() returns immediately. For example, when the global
   //       planner is idling while waiting for the next waypoint to be reached.
-  ros::Rate max_rate(100 /*Hz*/);
+  ros::Rate max_rate(config_.max_planner_update_frequency);
 
   // Spin.
   while (ros::ok() && comm_->stateMachine()->currentState() !=

--- a/glocal_exploration_ros/src/glocal_system.cpp
+++ b/glocal_exploration_ros/src/glocal_system.cpp
@@ -128,8 +128,16 @@ void GlocalSystem::mainLoop() {
     loopIteration();
     ros::spinOnce();
 
-    // Sleep only if the maximum rate would otherwise be exceeded.
-    max_rate.sleep();
+    // Limit the maximum planner update frequency
+    // NOTE: The local planner is exempt from this rate limit since fast
+    //       restarts are useful when paths become infeasible.
+    //       Furthermore, collision avoidance is not affected since it runs
+    //       in a separate thread.
+    if (comm_->stateMachine()->currentState() !=
+        StateMachine::State::kLocalPlanning) {
+      // Sleep only if the maximum rate would otherwise be exceeded
+      max_rate.sleep();
+    }
   }
   LOG_IF(INFO, config_.verbosity >= 1)
       << "Glocal Exploration Planner finished planning.";

--- a/glocal_exploration_ros/src/planning/global/skeleton_planner.cpp
+++ b/glocal_exploration_ros/src/planning/global/skeleton_planner.cpp
@@ -643,6 +643,8 @@ bool SkeletonPlanner::searchSkeletonStartVertices(
       return false;
     }
   }
+
+  return true;
 }
 
 bool SkeletonPlanner::computePathToFrontier(

--- a/glocal_exploration_ros/src/planning/global/skeleton_planner.cpp
+++ b/glocal_exploration_ros/src/planning/global/skeleton_planner.cpp
@@ -730,19 +730,19 @@ bool SkeletonPlanner::computePathToFrontier(
 
 bool SkeletonPlanner::isFrontierPointObservableFromPosition(
     const Point& frontier_point, const Point& skeleton_vertex_point) {
-  // Check for occlusions.
-  if (comm_->map()->lineIntersectsSurfaceInGlobalMap(skeleton_vertex_point,
-                                                     frontier_point)) {
-    return false;
-  }
-
   // Check if the frontier point is within the LiDAR's FoV.
   const FloatingPoint vertical_offset =
       frontier_point.z() - skeleton_vertex_point.z();
   const FloatingPoint horizontal_offset =
       (frontier_point - skeleton_vertex_point).head<2>().norm();
-  return std::abs(std::atan2(vertical_offset, horizontal_offset)) <
-         config_.sensor_vertical_fov_rad / 2.f;
+  if (config_.sensor_vertical_fov_rad / 2.f <
+      std::abs(std::atan2(vertical_offset, horizontal_offset))) {
+    return false;
+  }
+
+  // Check for occlusions.
+  return !comm_->map()->lineIntersectsSurfaceInGlobalMap(skeleton_vertex_point,
+                                                         frontier_point);
 }
 
 }  // namespace glocal_exploration


### PR DESCRIPTION
Changes
- Avoid looping and republishing visuals at excessively high rates when the planners are idling (e.g. global planner waiting to reach a waypoint)
- Reorder individual checks in frontier visibility assessment so that the FoV check is performed first (fast) and already discard a large number of candidates for the ray trace check (slow)