### PR TITLE
Minor code cleanup

### DIFF
--- a/glocal_exploration/CMakeLists.txt
+++ b/glocal_exploration/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(glocal_exploration)
 
-set(CMAKE_CXX_STANDARD 17)
+add_definitions(-std=c++17 -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -fPIC -DEIGEN_INITIALIZE_MATRICES_BY_NAN)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 catkin_package()

--- a/glocal_exploration/include/glocal_exploration/planning/global/skeleton/global_vertex_id.h
+++ b/glocal_exploration/include/glocal_exploration/planning/global/skeleton/global_vertex_id.h
@@ -6,7 +6,8 @@
 #include "glocal_exploration/common.h"
 
 namespace glocal_exploration {
-using VertexIdElement = typeof(voxblox::SkeletonVertex::vertex_id);
+// NOTE: The VertexIdElement type must match voxblox::SkeletonVertex::vertex_id
+using VertexIdElement = int64_t;
 
 struct GlobalVertexId {
   SubmapId submap_id = -1;

--- a/glocal_exploration/src/planning/global/skeleton/skeleton_a_star.cpp
+++ b/glocal_exploration/src/planning/global/skeleton/skeleton_a_star.cpp
@@ -155,12 +155,14 @@ SkeletonAStar::searchClosestReachableSkeletonVertices(
       reachable_skeleton_vertices.emplace_back(
           candidate_start_vertex.global_vertex_id);
       if (n_closest <= reachable_skeleton_vertices.size()) {
-        return reachable_skeleton_vertices;
+        break;
       }
     } else {
       ++num_candidates_unreachable;
     }
   }
+
+  return reachable_skeleton_vertices;
 }
 
 bool SkeletonAStar::getPathBetweenVertices(

--- a/glocal_exploration/src/planning/global/submap_frontier_evaluator.cpp
+++ b/glocal_exploration/src/planning/global/submap_frontier_evaluator.cpp
@@ -39,8 +39,8 @@ void SubmapFrontierEvaluator::Config::printFields() const {
 
 SubmapFrontierEvaluator::SubmapFrontierEvaluator(
     const Config& config, std::shared_ptr<Communicator> communicator)
-    : config_(config.checkValid()),
-      GlobalPlannerBase(std::move(communicator)) {}
+    : GlobalPlannerBase(std::move(communicator)),
+      config_(config.checkValid()) {}
 
 void SubmapFrontierEvaluator::computeFrontiersForSubmap(
     const MapBase::SubmapData& data, const Point& initial_point) {
@@ -247,6 +247,10 @@ void SubmapFrontierEvaluator::computeFrontierCandidates(
           result.push_back(centerPointFromIndex(candidate, voxel_size));
           break;
         }
+        case MapBase::VoxelState::kOccupied:
+        default:
+          // We hit an obstacle.
+          break;
       }
     }
   }

--- a/glocal_exploration/src/planning/local/rh_rrt_star.cpp
+++ b/glocal_exploration/src/planning/local/rh_rrt_star.cpp
@@ -710,14 +710,14 @@ RHRRTStar::Connection* RHRRTStar::ViewPoint::addConnection(ViewPoint* target,
 }
 
 RHRRTStar::Connection* RHRRTStar::ViewPoint::getActiveConnection() {
-  if (active_connection < 0 || active_connection >= connections.size()) {
+  if (connections.size() <= active_connection) {
     return nullptr;
   }
   return connections[active_connection].second.get();
 }
 
 const RHRRTStar::Connection* RHRRTStar::ViewPoint::getActiveConnection() const {
-  if (active_connection < 0 || active_connection >= connections.size()) {
+  if (connections.size() <= active_connection) {
     return nullptr;
   }
   return connections[active_connection].second.get();

--- a/glocal_exploration_ros/CMakeLists.txt
+++ b/glocal_exploration_ros/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(glocal_exploration_ros)
 
-set(CMAKE_CXX_STANDARD 17)
+add_definitions(-std=c++17 -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -fPIC -DEIGEN_INITIALIZE_MATRICES_BY_NAN)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 catkin_package()

--- a/glocal_exploration_ros/src/glocal_system.cpp
+++ b/glocal_exploration_ros/src/glocal_system.cpp
@@ -152,6 +152,9 @@ void GlocalSystem::loopIteration() {
       global_planner_visualizer_->visualize();
       break;
     }
+    default:
+      // No need to do anything.
+      break;
   }
 
   // Move requests.

--- a/glocal_exploration_ros/src/planning/global/skeleton_planner.cpp
+++ b/glocal_exploration_ros/src/planning/global/skeleton_planner.cpp
@@ -61,10 +61,10 @@ void SkeletonPlanner::Config::printFields() const {
 SkeletonPlanner::SkeletonPlanner(
     const Config& config, const SkeletonAStar::Config& skeleton_a_star_config,
     std::shared_ptr<Communicator> communicator)
-    : config_(config.checkValid()),
-      SubmapFrontierEvaluator(config.submap_frontier_config, communicator),
+    : SubmapFrontierEvaluator(config.submap_frontier_config, communicator),
       num_replan_attempts_to_chosen_frontier_(0),
       is_backtracking_(false),
+      config_(config.checkValid()),
       skeleton_a_star_(skeleton_a_star_config, communicator) {
   LOG_IF(INFO, config_.verbosity >= 1) << "\n" << config_.toString();
 

--- a/glocal_exploration_ros/src/visualization/skeleton_visualizer.cpp
+++ b/glocal_exploration_ros/src/visualization/skeleton_visualizer.cpp
@@ -31,7 +31,7 @@ void SkeletonVisualizer::Config::fromRosParam() {
 
 SkeletonVisualizer::SkeletonVisualizer(
     const Config& config, const std::shared_ptr<Communicator>& communicator)
-    : config_(config.checkValid()), GlobalPlannerVisualizerBase(communicator) {
+    : GlobalPlannerVisualizerBase(communicator), config_(config.checkValid()) {
   // Reference planner.
   planner_ = std::dynamic_pointer_cast<SkeletonPlanner>(comm_->globalPlanner());
   if (!planner_) {


### PR DESCRIPTION
Main changes
- Stricter compile flags
- Removed out-of-order initializations in constructors
- Addressed missing return values for non-void functions
- Ensure all switch statements have a default case