### PR TITLE
Automatically order includes with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,32 @@ BasedOnStyle: Google
 ColumnLimit: 80
 DerivePointerAlignment: false
 PointerAlignment: Left
-IncludeBlocks: Preserve
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Spacers
+  - Regex:    '^<clang-format-priority-15>$'
+    Priority: 15
+  - Regex:    '^<clang-format-priority-25>$'
+    Priority: 25
+  - Regex:    '^<clang-format-priority-35>$'
+    Priority: 35
+  - Regex:    '^<clang-format-priority-45>$'
+    Priority: 45
+  # C system headers
+  - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
+    Priority: 20
+  # C++ system headers
+  - Regex:    '^[<"](algorithm|any|array|atomic|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|charconv|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|complex|condition_variable|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|execution|filesystem|forward_list|fstream|functional|future|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|limits|list|locale|map|memory|memory_resource|mutex|new|numeric|optional|ostream|queue|random|ratio|regex|scoped_allocator|set|shared_mutex|sstream|stack|stdexcept|streambuf|string|string_view|strstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector)[">]$'
+    Priority: 30
+  # Your project's h files (with angles)
+  - Regex: '^<glocal'
+    Priority: 41
+  # Other library h files (with angles)
+  - Regex:    '^<'
+    Priority: 40
+  # Your project's h files
+  - Regex:    '^"glocal'
+    Priority: 50
 ---
 Language: Proto
 BasedOnStyle: Google

--- a/glocal_exploration/include/glocal_exploration/common.h
+++ b/glocal_exploration/include/glocal_exploration/common.h
@@ -1,10 +1,10 @@
 #ifndef GLOCAL_EXPLORATION_COMMON_H_
 #define GLOCAL_EXPLORATION_COMMON_H_
 
+#include <Eigen/Geometry>
 #include <glog/logging.h>
 #include <kindr/minimal/quat-transformation.h>
 #include <voxblox/core/common.h>
-#include <Eigen/Geometry>
 
 namespace glocal_exploration {
 

--- a/glocal_exploration_ros/app/experiments/voxblox_evaluation_node.cpp
+++ b/glocal_exploration_ros/app/experiments/voxblox_evaluation_node.cpp
@@ -10,7 +10,6 @@
 
 #include <ros/ros.h>
 #include <std_srvs/Empty.h>
-
 #include <voxblox/core/tsdf_map.h>
 #include <voxblox/io/layer_io.h>
 

--- a/glocal_exploration_ros/include/glocal_exploration_ros/glocal_system.h
+++ b/glocal_exploration_ros/include/glocal_exploration_ros/glocal_system.h
@@ -7,8 +7,8 @@
 #include <ros/ros.h>
 #include <std_srvs/SetBool.h>
 
-#include <glocal_exploration/state/communicator.h>
 #include <glocal_exploration/3rd_party/config_utilities.hpp>
+#include <glocal_exploration/state/communicator.h>
 
 #include "glocal_exploration_ros/visualization/global_planner_visualizer_base.h"
 #include "glocal_exploration_ros/visualization/local_planner_visualizer_base.h"

--- a/glocal_exploration_ros/include/glocal_exploration_ros/mapping/voxblox_map.h
+++ b/glocal_exploration_ros/include/glocal_exploration_ros/mapping/voxblox_map.h
@@ -5,8 +5,8 @@
 #include <string>
 #include <vector>
 
-#include <glocal_exploration/mapping/map_base.h>
 #include <glocal_exploration/3rd_party/config_utilities.hpp>
+#include <glocal_exploration/mapping/map_base.h>
 
 #include "glocal_exploration_ros/mapping/threadsafe_wrappers/threadsafe_voxblox_server.h"
 

--- a/glocal_exploration_ros/include/glocal_exploration_ros/mapping/voxgraph_local_area.h
+++ b/glocal_exploration_ros/include/glocal_exploration_ros/mapping/voxgraph_local_area.h
@@ -6,10 +6,11 @@
 #include <string>
 #include <unordered_map>
 
-#include <glocal_exploration/mapping/map_base.h>
-#include <glocal_exploration/utils/frame_transformer.h>
 #include <voxgraph/common.h>
 #include <voxgraph/frontend/submap_collection/voxgraph_submap_collection.h>
+
+#include <glocal_exploration/mapping/map_base.h>
+#include <glocal_exploration/utils/frame_transformer.h>
 
 #include "glocal_exploration_ros/mapping/voxgraph_spatial_hash.h"
 

--- a/glocal_exploration_ros/include/glocal_exploration_ros/mapping/voxgraph_map.h
+++ b/glocal_exploration_ros/include/glocal_exploration_ros/mapping/voxgraph_map.h
@@ -5,8 +5,8 @@
 #include <string>
 #include <vector>
 
-#include <glocal_exploration/mapping/map_base.h>
 #include <glocal_exploration/3rd_party/config_utilities.hpp>
+#include <glocal_exploration/mapping/map_base.h>
 
 #include "glocal_exploration_ros/mapping/threadsafe_wrappers/threadsafe_voxblox_server.h"
 #include "glocal_exploration_ros/mapping/threadsafe_wrappers/threadsafe_voxgraph_server.h"

--- a/glocal_exploration_ros/include/glocal_exploration_ros/mapping/voxgraph_spatial_hash.h
+++ b/glocal_exploration_ros/include/glocal_exploration_ros/mapping/voxgraph_spatial_hash.h
@@ -7,10 +7,11 @@
 #include <unordered_set>
 #include <vector>
 
+#include <voxgraph/frontend/submap_collection/voxgraph_submap_collection.h>
+
 #include <glocal_exploration/common.h>
 #include <glocal_exploration/utils/frame_transformer.h>
 #include <glocal_exploration/utils/set_utils.h>
-#include <voxgraph/frontend/submap_collection/voxgraph_submap_collection.h>
 
 namespace glocal_exploration {
 class VoxgraphSpatialHash {

--- a/glocal_exploration_ros/include/glocal_exploration_ros/planning/global/skeleton_planner.h
+++ b/glocal_exploration_ros/include/glocal_exploration_ros/planning/global/skeleton_planner.h
@@ -10,12 +10,12 @@
 #include <geometry_msgs/PoseStamped.h>
 #include <ros/ros.h>
 
+#include <glocal_exploration/3rd_party/config_utilities.hpp>
+#include <glocal_exploration/planning/global/skeleton/relative_waypoint.h>
 #include <glocal_exploration/planning/global/skeleton/skeleton_a_star.h>
 #include <glocal_exploration/planning/global/skeleton/skeleton_submap_collection.h>
 #include <glocal_exploration/planning/global/submap_frontier_evaluator.h>
 #include <glocal_exploration/state/communicator.h>
-#include <glocal_exploration/3rd_party/config_utilities.hpp>
-#include "glocal_exploration/planning/global/skeleton/relative_waypoint.h"
 
 namespace glocal_exploration {
 /**

--- a/glocal_exploration_ros/include/glocal_exploration_ros/visualization/rh_rrt_star_visualizer.h
+++ b/glocal_exploration_ros/include/glocal_exploration_ros/visualization/rh_rrt_star_visualizer.h
@@ -8,8 +8,8 @@
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
 
-#include <glocal_exploration/planning/local/rh_rrt_star.h>
 #include <glocal_exploration/3rd_party/config_utilities.hpp>
+#include <glocal_exploration/planning/local/rh_rrt_star.h>
 
 #include "glocal_exploration_ros/visualization/local_planner_visualizer_base.h"
 

--- a/glocal_exploration_ros/src/conversions/ros_component_factory.cpp
+++ b/glocal_exploration_ros/src/conversions/ros_component_factory.cpp
@@ -3,9 +3,9 @@
 #include <memory>
 #include <string>
 
+#include <glocal_exploration/3rd_party/config_utilities.hpp>
 #include <glocal_exploration/planning/local/rh_rrt_star.h>
 #include <glocal_exploration/state/region_of_interest.h>
-#include <glocal_exploration/3rd_party/config_utilities.hpp>
 
 #include "glocal_exploration_ros/mapping/voxblox_map.h"
 #include "glocal_exploration_ros/mapping/voxgraph_map.h"


### PR DESCRIPTION
This PR updates the clang-format rules such that the project's `#include`s are automatically grouped and ordered according to our style convention.